### PR TITLE
Fix serial output for multiple images

### DIFF
--- a/Toolbox/Toolbox_Utils.ino
+++ b/Toolbox/Toolbox_Utils.ino
@@ -247,10 +247,10 @@ void exportToSerial() {
               for (uint8_t x = 0; x < imageVars.xDim; x++) {
 
                 if (y < yMax - 1) {
-                  printHex(imageVars.image[imageVars.imageIdx][y][x]);
+                  printHex(imageVars.image[z][y][x]);
                 }
                 else {
-                  printHex(static_cast<uint8_t>(imageVars.image[imageVars.imageIdx][y][x] & yMax_Mask));
+                  printHex(static_cast<uint8_t>(imageVars.image[z][y][x] & yMax_Mask));
                 }
                 Serial.print(F(","));
 


### PR DESCRIPTION
Index used in exportToSerial was always the current image, not the z value that's being iterated in the for loop. This resulted in the wrong data being output for any images but the current one.

This resolves issue #2